### PR TITLE
don't return exceptions, add export endpoint

### DIFF
--- a/ai-backend/src/api/v1.py
+++ b/ai-backend/src/api/v1.py
@@ -1,7 +1,14 @@
+import csv
+import logging
 import time
+from datetime import datetime
+from io import StringIO
 from os import getenv
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import UUID4
 from requests import Session
 
@@ -11,16 +18,37 @@ from src.models import Feedback, QueryIr
 from src.schemas.feedback import FeedbackRequest
 from src.schemas.query import QueryRequest
 
+logger = logging.getLogger(__name__)
+
+security = HTTPBasic()
+
 router = APIRouter(
     tags=["v1"],
     responses={404: {"description": "Not found"}},
 )
 
 
+def authenticate(credentials: Annotated[HTTPBasicCredentials, Depends(security)]):
+    valid_username = getenv("EXPORT_AUTH_USERNAME")
+    valid_password = getenv("EXPORT_AUTH_PASSWORD")
+
+    if not (
+        credentials.username == valid_username
+        and credentials.password == valid_password
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username
+
+
 @router.post("/query")
 async def save_query(request: QueryRequest, db: Session = Depends(get_db)):
     VALID_MODELS = getenv("VALID_MODELS").split(",")
     if request.model not in VALID_MODELS:
+        logger.error(f"Invalid model requested: {request.model}")
         raise HTTPException(
             status_code=400,
             detail="Invalid model name, available models are: "
@@ -49,18 +77,17 @@ async def save_query(request: QueryRequest, db: Session = Depends(get_db)):
         db.commit()
         db.refresh(query_ir)
     except Exception as e:
+        logger.error(f"Database error when saving query_ir: {str(e)}", exc_info=True)
         db.rollback()
-        raise HTTPException(
-            status_code=500, detail=f"Database error when saving query_ir: {str(e)}"
-        )
 
-    return query_ir
+    return {}
 
 
 @router.get("/query/{query_id}")
 async def get_query(query_id: UUID4, db: Session = Depends(get_db)):
     query = db.query(QueryIr).filter(QueryIr.id == query_id).first()
     if not query:
+        logger.warning(f"Query not found: {query_id}")
         raise HTTPException(status_code=404, detail="Query not found")
     return query
 
@@ -73,6 +100,7 @@ async def upsert_feedback(
     # Check if query exists
     query = db.query(QueryIr).filter(QueryIr.id == query_id).first()
     if not query:
+        logger.warning(f"Query not found for feedback: {query_id}")
         raise HTTPException(status_code=404, detail="Query not found")
 
     # Update or create feedback
@@ -92,6 +120,7 @@ async def upsert_feedback(
         db.commit()
         db.refresh(feedback)
     except Exception as e:
+        logger.error(f"Database error when saving feedback: {str(e)}", exc_info=True)
         db.rollback()
         raise HTTPException(
             status_code=500, detail=f"Database error when saving feedback: {str(e)}"
@@ -104,5 +133,39 @@ async def upsert_feedback(
 async def get_feedback(query_id: UUID4, db: Session = Depends(get_db)):
     feedback = db.query(Feedback).filter(Feedback.query_id == query_id).first()
     if not feedback:
+        logger.warning(f"Feedback not found for query ID: {query_id}")
         raise HTTPException(status_code=404, detail="Feedback not found")
     return feedback
+
+
+@router.get("/export-ir")
+async def export_queries(
+    start_date: datetime,
+    end_date: datetime,
+    db: Session = Depends(get_db),
+    _: str = Depends(authenticate),
+):
+    """Export queries_ir in CSV format within the specified date range."""
+    queries = (
+        db.query(QueryIr)
+        .filter(QueryIr.timestamp >= start_date, QueryIr.timestamp <= end_date)
+        .all()
+    )
+
+    output = StringIO()
+    writer = csv.writer(output)
+
+    columns = [column.name for column in QueryIr.__table__.columns]
+    writer.writerow(columns)
+
+    for query in queries:
+        writer.writerow([getattr(query, column) for column in columns])
+
+    output.seek(0)
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f"attachment; filename=queries_ir_{start_date.date()}_{end_date.date()}.csv"
+        },
+    )

--- a/ai-backend/src/main.py
+++ b/ai-backend/src/main.py
@@ -1,8 +1,11 @@
+import logging
 from os import getenv
 
 from fastapi import FastAPI
 
 from .api import v1
+
+logging.basicConfig(format="%(levelname)s - %(name)s:%(lineno)d - %(message)s")
 
 app = FastAPI(root_path=getenv("ROOT_PATH", ""))
 


### PR DESCRIPTION
- Instead of returning an exception on the query endpoint, we now just log it in the server side
- The 200 response is now empty as well
- Added an endpoint to export data from the queries_ir table. It requires basic auth and accepts an start and end date range