### PR TITLE
read prompts from yaml file

### DIFF
--- a/ai-backend/poetry.lock
+++ b/ai-backend/poetry.lock
@@ -3258,4 +3258,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f858a980eff90fd47ce5ea49e34edfbfc4faf0c24fa5b865937223ed0d972703"
+content-hash = "63d3c8e3180a9167ca3502f0170ef334dd2d060609e3fa64d93bc09a2f935604"

--- a/ai-backend/pyproject.toml
+++ b/ai-backend/pyproject.toml
@@ -12,6 +12,7 @@ llama-index = "^0.12.14"
 sqlalchemy = "^2.0.37"
 alembic = "^1.14.1"
 psycopg2-binary = "^2.9.10"
+pyyaml = "^6.0.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/ai-backend/src/config/prompts.yml
+++ b/ai-backend/src/config/prompts.yml
@@ -1,0 +1,37 @@
+# This file will be overriden in kubernetes-inspire
+expand_query:
+  default: |
+    Expand this query into a the query format used for a fulltext search
+    over the INSPIRE HEP database. Propose alternatives of the query to
+    maximize the recall and join those variantes using OR operators and
+    prepend each variant with the ft prefix. Provide only the expanded
+    query, without any explanation, introduction of comment.
+
+    Example of query:
+    how far are black holes?
+
+    Expanded query:
+    ft "how far are black holes" OR ft "distance from black holes" OR ft
+    "distances to black holes" OR ft "measurement of distance to black
+    holes"  OR ft "remoteness of black holes"  OR ft "distance to black
+    holes"  OR ft "how far are singularities"  OR ft "distance to
+    singularities"  OR ft "distances to event horizon"  OR ft "distance
+    from Schwarzschild radius" OR ft "black hole distance"
+
+    Query: {query}
+
+    Expanded query:
+
+generate_answer:
+  default: |
+    You are part of a Retrieval Augmented Generation system
+    (RAG) and are asked with a query and a context of results. Generate an
+    answer substantiated by the results provided and citing them using
+    their index when used to provide an answer text. Do not put two or more
+    references together (ex: use [1][2] instead of [1,2]. Do not generate an answer
+    that cannot be entailed from cited abstract, so all paragraphs should cite a
+    search result. End the answer with the query and a brief answer as
+    summary of the previous discussed results. Do not consider results
+    that are not related to the query and, if no specific answer can be
+    provided, assert that in the brief answer. Please follow the provided schema
+    to correctly format the different parts of your answer.


### PR DESCRIPTION
- Now prompts are read from a yaml file. The goal of this is to be able to make quick changes directly from https://github.com/cern-sis/kubernetes-inspire without having to rebuild the image every time, all while still being able to easily modify them locally for quick testing.
- The `prompts.yml` file contains for the moment one default prompt for each task, but it is possible to provide different prompts for each model for more flexibility (just adding a new entry with the model name)