### PR TITLE
fix fulltext langchain search

### DIFF
--- a/ai-backend/src/api/v1.py
+++ b/ai-backend/src/api/v1.py
@@ -46,15 +46,6 @@ def authenticate(credentials: Annotated[HTTPBasicCredentials, Depends(security)]
 
 @router.post("/query")
 async def save_query(request: QueryRequest, db: Session = Depends(get_db)):
-    VALID_MODELS = getenv("VALID_MODELS").split(",")
-    if request.model not in VALID_MODELS:
-        logger.error(f"Invalid model requested: {request.model}")
-        raise HTTPException(
-            status_code=400,
-            detail="Invalid model name, available models are: "
-            + ", ".join(VALID_MODELS),
-        )
-
     start_time = time.time()
     query_response = search(request.query, request.model, use_highlights=True)
     response_time = time.time() - start_time

--- a/ai-backend/src/config/prompts.yml
+++ b/ai-backend/src/config/prompts.yml
@@ -1,22 +1,25 @@
 # This file will be overriden in kubernetes-inspire
 expand_query:
   default: |
-    Expand this query into a the query format used for a fulltext search
-    over the INSPIRE HEP database. Propose alternatives of the query to
-    maximize the recall and join those variantes using OR operators and
-    prepend each variant with the ft prefix. Provide only the expanded
-    query, without any explanation, introduction of comment.
+    Expand this search query and propose 5 alternatives of the query to
+    maximize the recall. These queries will later be used by the application
+    to perform a fulltext search on InspireHEP literature records in OpenSearch.
+    Provide only a JSON object with a terms item that will contain the
+    array of 5 queries, without any explanation, introduction or comment.
 
     Example of query:
     how far are black holes?
 
-    Expanded query:
-    ft "how far are black holes" OR ft "distance from black holes" OR ft
-    "distances to black holes" OR ft "measurement of distance to black
-    holes"  OR ft "remoteness of black holes"  OR ft "distance to black
-    holes"  OR ft "how far are singularities"  OR ft "distance to
-    singularities"  OR ft "distances to event horizon"  OR ft "distance
-    from Schwarzschild radius" OR ft "black hole distance"
+    Example of expanded query:
+    {{
+      "terms": [
+        "how far are black holes",
+        "distance to black holes",
+        "distance to singularities",
+        "distances to event horizon",
+        "distance from Schwarzschild radius"
+      ]
+    }}
 
     Query: {query}
 
@@ -35,7 +38,7 @@ generate_answer:
     to the query and, if no specific answer can be provided, assert that in the brief
     answer. Format your response as JSON with the fields `brief`, `response` and `query`.
 
-    <QUERY>{query}</QUERY?
+    <QUERY>{query}</QUERY>
 
     <CONTEXT>
       {context}

--- a/ai-backend/src/ir_pipeline/chains.py
+++ b/ai-backend/src/ir_pipeline/chains.py
@@ -1,13 +1,14 @@
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.output_parsers import PydanticOutputParser, StrOutputParser
+from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import PromptTemplate
 
-from src.ir_pipeline.llm_response import LLMResponse
+from src.ir_pipeline.schemas import LLMResponse, Terms
 
 
 def create_query_expansion_chain(llm: BaseLanguageModel, system_prompt: str):
     prompt_template = PromptTemplate.from_template(system_prompt)
-    return prompt_template | llm | StrOutputParser()
+    output_parser = PydanticOutputParser(pydantic_object=Terms)
+    return prompt_template | llm | output_parser
 
 
 def create_answer_generation_chain(llm: BaseLanguageModel, system_prompt: str):

--- a/ai-backend/src/ir_pipeline/schemas.py
+++ b/ai-backend/src/ir_pipeline/schemas.py
@@ -5,3 +5,7 @@ class LLMResponse(BaseModel):
     response: str
     query: str
     brief: str
+
+
+class Terms(BaseModel):
+    terms: list[str]

--- a/ai-backend/src/ir_pipeline/utils/inspire_formatter.py
+++ b/ai-backend/src/ir_pipeline/utils/inspire_formatter.py
@@ -60,7 +60,9 @@ def format_reference(metadata: Dict) -> str:
     return output
 
 
-def clean_refs(answer: str, results: Dict) -> Tuple[str, List[str]]:
+def clean_refs(
+    answer: str, results: Dict, use_highlights: bool = False
+) -> Tuple[str, List[str]]:
     """Clean the references from the answer"""
 
     # Find references
@@ -75,7 +77,9 @@ def clean_refs(answer: str, results: Dict) -> Tuple[str, List[str]]:
     for i, hit in enumerate(results["hits"]["hits"]):
         if i not in unique_ordered:
             continue
-        formatted_references.append(format_reference(hit["metadata"]))
+        formatted_references.append(
+            format_reference(hit["_source" if use_highlights else "metadata"])
+        )
 
     new_i = 1
     for i in unique_ordered:


### PR DESCRIPTION
Fixes issues from #20 

- Update query expansion prompt
- Add `Terms` schema for the expansion response
- Pass `Terms` correctly to the OS search tool
- Use right field for ref cleaning
- Remove valid model filtering (we only have one deployed at a time anyway)
- Remove `max_tokens` option which doesn't seem necessary for vLLM and was causing issues