### PR TITLE
fix expanded_query format error when saving to db

### DIFF
--- a/ai-backend/src/ir_pipeline/orchestrator.py
+++ b/ai-backend/src/ir_pipeline/orchestrator.py
@@ -90,5 +90,7 @@ def search(query, model, use_highlights=False):
         "brief": answer.brief,
         "response": clean_response,
         "references": references,
-        "expanded_query": expanded_query,
+        "expanded_query": " OR ".join(
+            [f'ft "{term}"' for term in expanded_query.terms]
+        ),
     }


### PR DESCRIPTION
Converts the expanded_query (aka terms) back in to a string as we were getting errors when saving queries to DB. This is a temporary solution: the DB field should be changed to an array when we get rid of the inspire api search option which for now is still available.