### PR TITLE
add playground endpoint and ref formatter

### DIFF
--- a/ai-backend/alembic/versions/f933aed30548_fix_queries_ir_uuid_default.py
+++ b/ai-backend/alembic/versions/f933aed30548_fix_queries_ir_uuid_default.py
@@ -1,0 +1,26 @@
+"""fix_queries_ir_uuid_default
+
+Revision ID: f933aed30548
+Revises: 849b77b6dfe6
+Create Date: 2025-04-23 11:35:40.644658
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f933aed30548"
+down_revision: Union[str, None] = "849b77b6dfe6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("queries_ir", "id", server_default=sa.text("gen_random_uuid()"))
+
+
+def downgrade() -> None:
+    op.alter_column("queries_ir", "id", server_default=None)

--- a/ai-backend/src/api/v1.py
+++ b/ai-backend/src/api/v1.py
@@ -13,7 +13,7 @@ from pydantic import UUID4
 from requests import Session
 
 from src.database import SessionLocal, get_db
-from src.ir_pipeline.orchestrator import search
+from src.ir_pipeline.orchestrator import search, search_playground
 from src.ir_pipeline.schemas import Terms
 from src.ir_pipeline.tools.inspire import InspireOSFullTextSearchTool
 from src.models import Feedback, QueryIr, SearchFeedback
@@ -89,13 +89,20 @@ async def process_query_task(request: QueryRequest):
 
 
 @router.post("/query")
-def save_query(
+async def save_query(
     request: QueryRequest,
     background_tasks: BackgroundTasks,
 ):
     background_tasks.add_task(process_query_task, request)
 
     return {}
+
+
+@router.post("/query-playground")
+async def playground_query(request: QueryRequest):
+    """Returns responses in a format suitable for the playground."""
+    response = await search_playground(request.query, request.model)
+    return response
 
 
 @router.get("/query/{query_id}")

--- a/ai-backend/src/ir_pipeline/chains.py
+++ b/ai-backend/src/ir_pipeline/chains.py
@@ -1,33 +1,59 @@
+import logging
+
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.runnables import RunnableConfig
 from langfuse import Langfuse
+from langfuse.api.resources.commons.errors.not_found_error import NotFoundError
 
 from src.ir_pipeline.schemas import LLMResponse, Terms
+
+logger = logging.getLogger(__name__)
 
 langfuse = Langfuse()
 
 
 def _get_prompt(prompt_name: str):
-    langfuse_prompt = langfuse.get_prompt(prompt_name)  # default cache_ttl_seconds=0
-    return PromptTemplate.from_template(
+    def fetch_prompt(label: str = None):
+        return langfuse.get_prompt(
+            prompt_name,
+            cache_ttl_seconds=0 if langfuse.environment == "local" else None,
+            label=label,
+        )
+
+    try:
+        langfuse_prompt = fetch_prompt(label=langfuse.environment)
+    except NotFoundError:
+        logger.warning(
+            f"Prompt '{prompt_name}' or label '{langfuse.environment}' not found in Langfuse, trying label 'production'"
+        )
+        langfuse_prompt = fetch_prompt()
+
+    prompt_template = PromptTemplate.from_template(
         langfuse_prompt.get_langchain_prompt(),
         metadata={"langfuse_prompt": langfuse_prompt},
     )
+    return prompt_template, langfuse_prompt
 
 
 def create_query_expansion_chain(llm: BaseLanguageModel):
+    prompt_template, langfuse_prompt = _get_prompt("expand-query")
     output_parser = PydanticOutputParser(pydantic_object=Terms)
-    config = RunnableConfig(run_name="expand_query")
-    get_prompt = RunnableLambda(lambda _: _get_prompt("expand-query"))
-    chain = get_prompt | llm | output_parser
+    config = RunnableConfig(
+        run_name="expand-query", metadata={"langfuse_prompt": langfuse_prompt}
+    )
+    chain = prompt_template | llm | output_parser
     return chain.with_config(config)
 
 
-def create_answer_generation_chain(llm: BaseLanguageModel):
+def create_answer_generation_chain(
+    llm: BaseLanguageModel, prompt_name: str = "generate-answer"
+):
+    prompt_template, langfuse_prompt = _get_prompt(prompt_name)
     output_parser = PydanticOutputParser(pydantic_object=LLMResponse)
-    config = RunnableConfig(run_name="generate_answer")
-    get_prompt = RunnableLambda(lambda _: _get_prompt("generate-answer"))
-    chain = get_prompt | llm | output_parser
+    config = RunnableConfig(
+        run_name=prompt_name, metadata={"langfuse_prompt": langfuse_prompt}
+    )
+    chain = prompt_template | llm | output_parser
     return chain.with_config(config)

--- a/ai-backend/src/ir_pipeline/schemas.py
+++ b/ai-backend/src/ir_pipeline/schemas.py
@@ -3,7 +3,6 @@ from pydantic import BaseModel
 
 class LLMResponse(BaseModel):
     response: str
-    query: str
     brief: str
 
 

--- a/ai-backend/src/main.py
+++ b/ai-backend/src/main.py
@@ -2,6 +2,7 @@ import logging
 from os import getenv
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from .api import v1
@@ -11,5 +12,14 @@ logging.basicConfig(format="%(levelname)s - %(name)s:%(lineno)d - %(message)s")
 app = FastAPI(root_path=getenv("ROOT_PATH", ""))
 
 app.include_router(v1.router, prefix="/v1")
+
+if getenv("ENV") == "local":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 Instrumentator().instrument(app).expose(app)


### PR DESCRIPTION
- Adds a new `query_playground` endpoint that will return responses from the LLM formatted appropriately to be used in the playground
- Adds new reference formatter to include snippets and paperId in the final response to be able to use in playground
- Uses a new, slightly modified answer generation prompt. Also adds support for prompt labels (with the idea of migrating to a single langfuse project with different labels per environment) and falls back to the production label if a prompt with the label corresponding to the environment is not found
- Configures CORS for local dev
- The migration is a leftover from last time (it is already applied to qa and prod so no worries about that)