### PR TITLE
playground: use corresponding backend instance per env

### DIFF
--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -7,7 +7,8 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile 
 COPY . .
 
-ENV NODE_ENV=production
+ARG ENVIRONMENT
+ENV NODE_ENV=$ENVIRONMENT
 RUN bun run build
 
 FROM nginx:alpine AS prod

--- a/playground/src/views/PrimaryView.tsx
+++ b/playground/src/views/PrimaryView.tsx
@@ -27,6 +27,12 @@ const PrimaryView = () => {
   const [activePaper, setActivePaper] = useState<PaperDetails | null>(null);
   const resizableGroup = useRef<ImperativePanelGroupHandle>(null);
 
+  const inspireApiUrl = import.meta.env.DEV
+    ? ""
+    : import.meta.env.NODE_ENV === "prod"
+      ? "https://inspirehep.net"
+      : "https://inspirebeta.net";
+
   const [formattedCitations, setFormattedCitations] = useState<
     FormattedCitation[]
   >([]);
@@ -38,7 +44,7 @@ const PrimaryView = () => {
 
     try {
       const llmResponse: LLMResponse = await fetch(
-        `https://inspirehep.net/ai/v1/query-rag`,
+        `${inspireApiUrl}/ai/v1/query-rag`,
         {
           method: "POST",
           headers: {

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -13,4 +13,13 @@ export default defineConfig({
       "@": path.resolve(path.dirname(fileURLToPath(import.meta.url)), "./src"),
     },
   },
+  server: {
+    proxy: {
+      "^/ai/.*": {
+        target: "https://inspirebeta.net",
+        changeOrigin: true,
+        secure: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Closes https://github.com/cern-sis/issues-inspire/issues/975

Passes down the env from an `ENVIRONMENT` variable coming from k8s