### PR TITLE
playground: speed up pdf loading

### DIFF
--- a/playground/src/components/pdf/PDFManager.tsx
+++ b/playground/src/components/pdf/PDFManager.tsx
@@ -1,0 +1,40 @@
+import { getPaperUrl } from "@/lib/utils";
+
+import PDFViewer from "@/components/pdf/PDFViewer";
+
+import { PaperDetails } from "@/types";
+
+interface PDFManagerProps {
+  papers: PaperDetails[];
+  activePaper: PaperDetails | null;
+  highlight?: string;
+}
+
+// Renders a PDF viewer for each paper in the list in order to pre-load them and speed up switching between them
+const PDFManager = ({ papers, activePaper, highlight }: PDFManagerProps) => {
+  return (
+    <div className="relative h-full w-full">
+      {papers.map((paper) => {
+        const pdfUrl = getPaperUrl(paper);
+        if (!pdfUrl) return null;
+
+        const isActive = activePaper?.id === paper.id;
+
+        return (
+          <div key={paper.id} className={`${isActive ? "block" : "hidden"}`}>
+            <PDFViewer
+              pdfUrl={pdfUrl}
+              highlight={
+                isActive && activePaper?.highlight
+                  ? activePaper.highlight.slice(0, 15)
+                  : highlight
+              }
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PDFManager;

--- a/playground/src/hooks/usePDFCache.ts
+++ b/playground/src/hooks/usePDFCache.ts
@@ -1,0 +1,37 @@
+const pdfCache = new Map<string, string>();
+const pendingRequests = new Map<string, Promise<string | null>>();
+
+export const usePDFCache = () => {
+  const getCachedPDF = (url: string): string | null => {
+    return pdfCache.get(url) || null;
+  };
+
+  const cachePDF = (url: string, blob: string) => {
+    pdfCache.set(url, blob);
+    pendingRequests.delete(url);
+  };
+
+  const getPendingRequest = (url: string): Promise<string | null> | null => {
+    return pendingRequests.get(url) || null;
+  };
+
+  const setPendingRequest = (url: string, promise: Promise<string | null>) => {
+    pendingRequests.set(url, promise);
+  };
+
+  const clearCache = () => {
+    pdfCache.forEach((blobUrl) => {
+      URL.revokeObjectURL(blobUrl);
+    });
+    pdfCache.clear();
+    pendingRequests.clear();
+  };
+
+  return {
+    getCachedPDF,
+    cachePDF,
+    getPendingRequest,
+    setPendingRequest,
+    clearCache,
+  };
+};

--- a/playground/src/lib/api.ts
+++ b/playground/src/lib/api.ts
@@ -46,6 +46,12 @@ export interface InspirePaper {
       value: string;
     }>;
     document_type?: string[];
+    documents?: Array<{
+      source?: string;
+      fulltext?: boolean;
+      key?: string;
+      url?: string;
+    }>;
   };
   created: string;
   updated: string;
@@ -118,12 +124,17 @@ export async function searchPapers(
 
 /**
  * Get a specific paper by ID
+ * Passes the UI content-type in order to fech some extra details like inspire PDF URL
  */
 export async function getPaperById(id: string): Promise<InspirePaper> {
   const url = `${API_BASE_URL}/literature/${id}`;
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd+inspire.record.ui+json",
+      },
+    });
 
     if (!response.ok) {
       throw new Error(`API request failed with status ${response.status}`);
@@ -167,7 +178,8 @@ export function convertInspirePaperToAppFormat(
     citation_count: metadata.citation_count || 0,
     arxiv_id: metadata.arxiv_eprints?.[0]?.value,
     doi: metadata.dois?.[0]?.value,
-    document_type: metadata.document_type?.[0] || "article",
+    document_type: metadata.document_type?.[0],
+    document_url: metadata.documents?.find((d) => d.source == "arxiv")?.url,
   };
 }
 

--- a/playground/src/lib/utils.ts
+++ b/playground/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+import { PaperDetails } from "@/types";
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -25,4 +27,48 @@ export const formatAuthors = (
     return authors.join(", ");
   }
   return `${authors.slice(0, count).join(", ")} et al.`;
+};
+
+export const getPaperUrl = (paper: PaperDetails) =>
+  paper.arxiv_id &&
+  (paper.document_url ||
+    `https://browse-export.arxiv.org/pdf/${paper.arxiv_id}`);
+
+export const getPDFWithCache = async (
+  pdfUrl: string,
+  getCachedPDF: (url: string) => string | null,
+  cachePDF: (url: string, blob: string) => void,
+  getPendingRequest: (url: string) => Promise<string | null> | null,
+  setPendingRequest: (url: string, promise: Promise<string | null>) => void,
+): Promise<string | null> => {
+  const cached = getCachedPDF(pdfUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = getPendingRequest(pdfUrl);
+  if (pending) {
+    const result = await pending;
+    return getCachedPDF(pdfUrl) || result;
+  }
+
+  const fetchPromise = (async () => {
+    try {
+      const response = await fetch(pdfUrl);
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      return blobUrl;
+    } catch {
+      return null;
+    }
+  })();
+
+  setPendingRequest(pdfUrl, fetchPromise);
+
+  const blobUrl = await fetchPromise;
+  if (blobUrl) {
+    cachePDF(pdfUrl, blobUrl);
+  }
+
+  return blobUrl;
 };


### PR DESCRIPTION
Closes https://github.com/cern-sis/issues-inspire/issues/977

- Now fetching PDFs from inspire when available, otherwise falling back to arxiv
- PDFs for **all** papers are fetched immediately and in parallel when the response is received, and they are cached locally as blobs. While loading, they will be saved as pending.
- When opening a paper, the PDF viewer will load **all** the PDFs from the cache in parallel. If any PDF is pending, it will just await it to avoid duplicate requests, otherwise (if for some reason it hasn't been fetched at all) it will retry, if it doesn't work, it will display an error.

With these changes PDFs load faster and switching back and forth between papers is almost instant.