### PR TITLE
playground: use corresponding inspire env

### DIFF
--- a/playground/src/components/paper/CollaborationDisplay.tsx
+++ b/playground/src/components/paper/CollaborationDisplay.tsx
@@ -1,3 +1,5 @@
+import { getInspireBaseUrl } from "@/lib/utils";
+
 import { Button } from "@/components/ui/button";
 
 export function CollaborationDisplay({
@@ -11,7 +13,7 @@ export function CollaborationDisplay({
         <span key={collaboration}>
           <Button variant="link" size="sm" className="h-4 p-0" asChild>
             <a
-              href={`https://inspirehep.net/literature?q=collaboration:${collaboration}`}
+              href={`${getInspireBaseUrl()}/literature?q=collaboration:${collaboration}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/playground/src/components/paper/PaperHeader.tsx
+++ b/playground/src/components/paper/PaperHeader.tsx
@@ -1,4 +1,4 @@
-import { formatAuthors } from "@/lib/utils";
+import { formatAuthors, getInspireBaseUrl } from "@/lib/utils";
 import { Award, X } from "lucide-react";
 import { useEffect } from "react";
 
@@ -119,7 +119,7 @@ export function PaperHeader({ paper, onClose }: PaperHeaderProps) {
                       asChild
                     >
                       <a
-                        href={`https://inspirehep.net/literature/${paper.id}`}
+                        href={`${getInspireBaseUrl()}/literature/${paper.id}`}
                         target="_blank"
                         rel="noopener noreferrer"
                       >

--- a/playground/src/lib/api.ts
+++ b/playground/src/lib/api.ts
@@ -1,8 +1,9 @@
 /**
  * Service for interacting with the INSPIRE HEP API
  */
+import { getInspireBaseUrl } from "./utils";
 
-const API_BASE_URL = "https://inspirehep.net/api";
+const API_BASE_URL = `${getInspireBaseUrl()}/api`;
 
 export interface InspireSearchParams {
   q?: string;

--- a/playground/src/lib/utils.ts
+++ b/playground/src/lib/utils.ts
@@ -7,8 +7,21 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export const getInspireBaseUrl = (() => {
+  let cached: string | null = null;
+
+  return (): string => {
+    if (cached === null) {
+      cached = window.location.hostname.includes("inspirehep.net")
+        ? "https://inspirehep.net"
+        : "https://inspirebeta.net";
+    }
+    return cached;
+  };
+})();
+
 export const getCitationsUrl = (paperId: string) => {
-  return `https://inspirehep.net/literature?q=refersto%3Arecid%3A${paperId}`;
+  return `${getInspireBaseUrl()}/literature?q=refersto%3Arecid%3A${paperId}`;
 };
 
 export const formatAuthors = (


### PR DESCRIPTION
Use inspirebeta for all requests from QA playground (files, api, etc)