### PR TITLE
add paper chat support

### DIFF
--- a/ai-backend/backend/src/ir_pipeline/chains.py
+++ b/ai-backend/backend/src/ir_pipeline/chains.py
@@ -1,4 +1,4 @@
-from backend.src.ir_pipeline.schema import LLMResponse, Terms
+from backend.src.ir_pipeline.schema import LLMPaperResponse, LLMResponse, Terms
 from backend.src.utils.langfuse import get_prompt
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import PydanticOutputParser
@@ -32,6 +32,16 @@ def create_rag_answer_generation_chain(llm: BaseLanguageModel):
     output_parser = PydanticOutputParser(pydantic_object=LLMResponse)
     config = RunnableConfig(
         run_name="rag-query", metadata={"langfuse_prompt": langfuse_prompt}
+    )
+    chain = prompt_template | llm | output_parser
+    return chain.with_config(config)
+
+
+def create_rag_paper_answer_generation_chain(llm: BaseLanguageModel):
+    prompt_template, langfuse_prompt = get_prompt("rag-paper-query")
+    output_parser = PydanticOutputParser(pydantic_object=LLMPaperResponse)
+    config = RunnableConfig(
+        run_name="rag-paper-query", metadata={"langfuse_prompt": langfuse_prompt}
     )
     chain = prompt_template | llm | output_parser
     return chain.with_config(config)

--- a/ai-backend/backend/src/ir_pipeline/schema.py
+++ b/ai-backend/backend/src/ir_pipeline/schema.py
@@ -6,5 +6,9 @@ class LLMResponse(BaseModel):
     brief: str
 
 
+class LLMPaperResponse(BaseModel):
+    response: str
+
+
 class Terms(BaseModel):
     terms: list[str]

--- a/ai-backend/backend/src/schemas/query.py
+++ b/ai-backend/backend/src/schemas/query.py
@@ -4,11 +4,18 @@ from typing import List, Optional
 from pydantic import UUID4, BaseModel
 
 
+class ChatMessage(BaseModel):
+    type: str  # "user" or "assistant"
+    content: str
+
+
 class QueryRequest(BaseModel):
     query: str
     model: str = getenv("LLM_MODEL")
     user: Optional[str] = None
     matomo_client_id: Optional[UUID4] = None
+    control_number: Optional[int] = None
+    history: Optional[List[ChatMessage]] = None
 
 
 class Citation(BaseModel):
@@ -21,3 +28,7 @@ class QueryResponse(BaseModel):
     brief_answer: str
     long_answer: str
     citations: List[Citation]
+
+
+class QueryPaperResponse(BaseModel):
+    long_answer: str

--- a/ai-backend/backend/src/utils/langfuse.py
+++ b/ai-backend/backend/src/utils/langfuse.py
@@ -9,19 +9,21 @@ logger = logging.getLogger(__name__)
 langfuse = Langfuse()
 
 
+# Locally langfuse.environment should be unset (None)
 def get_prompt(prompt_name: str):
     def fetch_prompt(label: str = None):
         return langfuse.get_prompt(
             prompt_name,
-            cache_ttl_seconds=0 if langfuse.environment == "local" else None,
+            cache_ttl_seconds=0 if langfuse.environment is None else None,
             label=label,
         )
 
     try:
-        langfuse_prompt = fetch_prompt(label=langfuse.environment)
+        label = "latest" if langfuse.environment is None else langfuse.environment
+        langfuse_prompt = fetch_prompt(label=label)
     except NotFoundError:
         logger.warning(
-            f"Prompt '{prompt_name}' or label '{langfuse.environment}' "
+            f"Prompt '{prompt_name}' or label '{label}' "
             f"not found in Langfuse, trying label 'production'"
         )
         langfuse_prompt = fetch_prompt()

--- a/playground/src/components/PaperChat.tsx
+++ b/playground/src/components/PaperChat.tsx
@@ -1,0 +1,228 @@
+import { usePaperChatHistory } from "@/hooks/usePaperChatHistory";
+import { getInspireAiUrl } from "@/lib/utils";
+import { FileSearch2, Lightbulb, Loader2, Send } from "lucide-react";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import Latex from "@/components/paper/Latex";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loading } from "@/components/ui/loading";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+import { ChatMessage, PaperDetails, QueryRequest } from "@/types";
+
+interface PaperChatProps {
+  activePaper: PaperDetails;
+}
+
+const PaperChat = ({ activePaper }: PaperChatProps) => {
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
+
+  const { getChatHistory, updateChatHistory } = usePaperChatHistory();
+  const chatHistory = getChatHistory(activePaper.id);
+
+  const suggestedQuestions = [
+    { label: "Summary", fullQuestion: "Provide a summary of this paper" },
+    {
+      label: "Contributions",
+      fullQuestion: "What are the main contributions?",
+    },
+    { label: "Methodology", fullQuestion: "Explain the methodology used" },
+    {
+      label: "Limitations",
+      fullQuestion: "What are the limitations mentioned?",
+    },
+    { label: "Conclusions", fullQuestion: "What are the key conclusions?" },
+    {
+      label: "Study Guide",
+      fullQuestion: "Create a study guide for this paper",
+    },
+  ];
+
+  useEffect(() => {
+    if (scrollAreaRef.current) {
+      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
+    }
+  }, [chatHistory]);
+
+  const handlePaperSearch = async (searchQuery: string) => {
+    if (!searchQuery.trim()) return;
+
+    const userMessage: ChatMessage = {
+      type: "user",
+      content: searchQuery,
+    };
+
+    updateChatHistory(activePaper.id, [...chatHistory, userMessage]);
+    setIsLoading(true);
+    setQuery("");
+
+    try {
+      const requestBody: QueryRequest = {
+        query: searchQuery,
+        control_number: Number(activePaper.id),
+        history: chatHistory,
+      };
+
+      const paperResponseData: { long_answer: string } = await fetch(
+        `${getInspireAiUrl()}/v1/query-rag`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(requestBody),
+        },
+      ).then((res) => res.json());
+
+      const assistantMessage: ChatMessage = {
+        type: "assistant",
+        content: paperResponseData.long_answer,
+      };
+
+      const updatedHistory = [...chatHistory, userMessage, assistantMessage];
+      updateChatHistory(activePaper.id, updatedHistory);
+    } catch {
+      toast.error("Something went wrong. Please try again later.");
+      updateChatHistory(activePaper.id, chatHistory);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSearch = async (e: FormEvent) => {
+    e.preventDefault();
+    await handlePaperSearch(query);
+  };
+
+  const handleSuggestedQuestion = async (question: string) => {
+    setIsPopoverOpen(false);
+    await handlePaperSearch(question);
+  };
+
+  const renderChatMessage = (message: ChatMessage, index: number) => (
+    <div
+      key={index}
+      className={`mb-6 ${message.type === "user" ? "text-right" : "text-left"}`}
+    >
+      {message.type === "user" ? (
+        <div className="bg-muted text-primary inline-block max-w-[80%] rounded-2xl px-4 py-3 text-sm">
+          <div className="whitespace-pre-wrap">{message.content}</div>
+        </div>
+      ) : (
+        <div className="max-w-[90%]">
+          <div className="text-foreground prose prose-sm dark:prose-invert text-sm leading-relaxed">
+            <Latex>{message.content}</Latex>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  const renderSuggestions = () => (
+    <>
+      <div className="mb-4 flex items-center justify-center gap-2">
+        <Lightbulb className="h-4 w-4" />
+        <h4 className="text-sm font-semibold">Quick Questions</h4>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {suggestedQuestions.map((question, index) => (
+          <Button
+            key={index}
+            type="button"
+            variant="secondary"
+            onClick={() => handleSuggestedQuestion(question.fullQuestion)}
+            disabled={isLoading}
+            className="font-normal"
+          >
+            {question.label}
+          </Button>
+        ))}
+      </div>
+    </>
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-hidden">
+        <div className="h-full overflow-y-auto p-4" ref={scrollAreaRef}>
+          {chatHistory.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-10 text-center">
+              <div>
+                <FileSearch2
+                  className="mx-auto mb-4 h-12 w-12"
+                  strokeWidth={1}
+                />
+                <p className="mb-1 text-base font-medium">
+                  Ask questions about this paper
+                </p>
+                <p className="text-sm opacity-75">
+                  Start a conversation to get specific insights and details
+                </p>
+              </div>
+              <div className="rounded-xl border p-5">{renderSuggestions()}</div>
+            </div>
+          ) : (
+            chatHistory.map(renderChatMessage)
+          )}
+          {isLoading && (
+            <div className="mb-6">
+              <Loading />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <form onSubmit={handleSearch} className="px-10 py-3">
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Input
+              type="text"
+              placeholder="Ask questions about this paper..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className={`h-12 ${chatHistory.length > 0 ? "pr-12" : ""}`}
+              disabled={isLoading}
+            />
+            {chatHistory.length > 0 && (
+              <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    disabled={isLoading}
+                    className="absolute top-1/2 right-2 h-8 w-8 -translate-y-1/2"
+                  >
+                    <Lightbulb className="h-4 w-4" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent side="top" align="end" className="mb-4">
+                  {renderSuggestions()}
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
+          <Button
+            type="submit"
+            size="icon"
+            disabled={isLoading || !query.trim()}
+            className="h-12 w-12"
+          >
+            {isLoading ? <Loader2 className="animate-spin" /> : <Send />}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default PaperChat;

--- a/playground/src/components/ThemeToggle.tsx
+++ b/playground/src/components/ThemeToggle.tsx
@@ -81,6 +81,7 @@ export function ThemeToggle({ className }: { className?: string }) {
       <Button
         variant="ghost"
         size="icon"
+        style={{ borderRadius: "50%" }}
         className={className}
         onClick={transitTheme}
       >

--- a/playground/src/components/paper/PaperHeader.tsx
+++ b/playground/src/components/paper/PaperHeader.tsx
@@ -1,16 +1,11 @@
-import { formatAuthors, getInspireBaseUrl } from "@/lib/utils";
-import { Award, X } from "lucide-react";
+import { formatAuthors, getCitationsUrl, getInspireBaseUrl } from "@/lib/utils";
+import { ArrowLeft, Award } from "lucide-react";
 import { useEffect } from "react";
 
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { AuthorsModal } from "@/components/paper/AuthorsModal";
 import { CollaborationDisplay } from "@/components/paper/CollaborationDisplay";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 import { PaperDetails } from "@/types";
 
@@ -45,14 +40,26 @@ export function PaperHeader({ paper, onClose }: PaperHeaderProps) {
     <div className="bg-background/95 fixed top-0 right-0 left-0 h-[5rem] border-b py-4 pl-0 backdrop-blur">
       <div className="flex h-full items-center justify-between">
         <div className="flex items-center gap-4">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onClose}
-            className="h-[5rem] w-[5rem]"
-          >
-            <InspireInSvg className="size-10" />
-          </Button>
+          <div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="h-[5rem] w-[5rem]"
+              aria-label="Back"
+            >
+              <ArrowLeft className="size-10" strokeWidth={1.1} />
+            </Button>
+
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="h-[5rem] w-[5rem]"
+            >
+              <InspireInSvg className="size-10" />
+            </Button>
+          </div>
           <div className="flex flex-col gap-2">
             <h2 className="line-clamp-1 text-xl font-semibold">
               {paper.title}
@@ -103,7 +110,7 @@ export function PaperHeader({ paper, onClose }: PaperHeaderProps) {
                     asChild
                   >
                     <a
-                      href={`https://inspirehep.net/literature/${paper.id}`}
+                      href={`${getInspireBaseUrl()}/literature/${paper.id}`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -119,7 +126,7 @@ export function PaperHeader({ paper, onClose }: PaperHeaderProps) {
                       asChild
                     >
                       <a
-                        href={`${getInspireBaseUrl()}/literature/${paper.id}`}
+                        href={getCitationsUrl(paper.id)}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
@@ -133,29 +140,7 @@ export function PaperHeader({ paper, onClose }: PaperHeaderProps) {
             </p>
           </div>
         </div>
-        <div className="flex items-center">
-          <ThemeToggle className="text-muted-foreground h-[5rem]" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onClose}
-                className="h-[5rem] w-[5rem]"
-              >
-                <X className="size-10" strokeWidth={1.1} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent className="py-2">
-              <span>
-                Close{" "}
-                <kbd className="bg-muted-foreground px-2 py-1 font-mono">
-                  Esc
-                </kbd>
-              </span>
-            </TooltipContent>
-          </Tooltip>
-        </div>
+        <ThemeToggle className="text-muted-foreground m-5" />
       </div>
     </div>
   );

--- a/playground/src/components/pdf/PDFViewer.tsx
+++ b/playground/src/components/pdf/PDFViewer.tsx
@@ -2,6 +2,7 @@
 import { usePDFCache } from "@/hooks/usePDFCache";
 import { getPDFWithCache } from "@/lib/utils";
 import {
+  AnnotationLayer,
   CanvasLayer,
   HighlightLayer,
   Page,
@@ -10,13 +11,13 @@ import {
   Search,
   TextLayer,
 } from "@anaralabs/lector";
-import { Loader2 } from "lucide-react";
 import { GlobalWorkerOptions } from "pdfjs-dist";
 import "pdfjs-dist/web/pdf_viewer.css";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import PDFSearch from "@/components/pdf/PDFSearch";
+import { Loading } from "@/components/ui/loading";
 
 GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/build/pdf.worker.mjs",
@@ -56,8 +57,7 @@ const PDFViewer = ({
 
   const LoadingSpinner = () => (
     <div className="absolute inset-0 flex items-center justify-center">
-      <Loader2 className="text-primary h-8 w-8 animate-spin" />
-      <span className="ml-2">Loading...</span>
+      <Loading text="Loading PDF..." />
     </div>
   );
 
@@ -76,6 +76,7 @@ const PDFViewer = ({
           <Page>
             <CanvasLayer />
             <TextLayer />
+            <AnnotationLayer />
             <HighlightLayer className="bg-yellow-200/70" />
           </Page>
         </Pages>

--- a/playground/src/components/ui/loading.tsx
+++ b/playground/src/components/ui/loading.tsx
@@ -1,0 +1,16 @@
+function Loading({ text = "Thinking..." }: { text?: string }) {
+  return (
+    <div className="text-muted-foreground flex items-center gap-1">
+      {[0, 0.2, 0.4].map((delay) => (
+        <div
+          key={delay}
+          className="h-2 w-2 animate-pulse rounded-full bg-current"
+          style={delay ? { animationDelay: `${delay}s` } : undefined}
+        />
+      ))}
+      <span className="ml-2 text-sm">{text}</span>
+    </div>
+  );
+}
+
+export { Loading };

--- a/playground/src/hooks/usePaperChatHistory.ts
+++ b/playground/src/hooks/usePaperChatHistory.ts
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+import { ChatMessage } from "@/types";
+
+interface UsePaperChatHistoryReturn {
+  getChatHistory: (paperId: string) => ChatMessage[];
+  updateChatHistory: (paperId: string, messages: ChatMessage[]) => void;
+  clearHistory: (paperId: string) => void;
+  clearAllHistories: () => void;
+}
+
+export const usePaperChatHistory = (): UsePaperChatHistoryReturn => {
+  const [paperChatHistories, setPaperChatHistories] = useState<
+    Record<string, ChatMessage[]>
+  >({});
+
+  const getChatHistory = (paperId: string): ChatMessage[] => {
+    return paperChatHistories[paperId] || [];
+  };
+
+  const updateChatHistory = (paperId: string, messages: ChatMessage[]) => {
+    setPaperChatHistories((prev) => ({
+      ...prev,
+      [paperId]: messages,
+    }));
+  };
+
+  const clearHistory = (paperId: string) => {
+    setPaperChatHistories((prev) => {
+      const updated = { ...prev };
+      delete updated[paperId];
+      return updated;
+    });
+  };
+
+  const clearAllHistories = () => {
+    setPaperChatHistories({});
+  };
+
+  return {
+    getChatHistory,
+    updateChatHistory,
+    clearHistory,
+    clearAllHistories,
+  };
+};

--- a/playground/src/lib/utils.ts
+++ b/playground/src/lib/utils.ts
@@ -20,6 +20,9 @@ export const getInspireBaseUrl = (() => {
   };
 })();
 
+export const getInspireAiUrl = () =>
+  `${import.meta.env.DEV ? "" : getInspireBaseUrl()}/ai`;
+
 export const getCitationsUrl = (paperId: string) => {
   return `${getInspireBaseUrl()}/literature?q=refersto%3Arecid%3A${paperId}`;
 };
@@ -37,9 +40,9 @@ export const formatAuthors = (
   }
 
   if (authors.length <= count) {
-    return authors.join(", ");
+    return authors.join("; ");
   }
-  return `${authors.slice(0, count).join(", ")} et al.`;
+  return `${authors.slice(0, count).join("; ")} et al.`;
 };
 
 export const getPaperUrl = (paper: PaperDetails) =>

--- a/playground/src/types/index.ts
+++ b/playground/src/types/index.ts
@@ -12,6 +12,21 @@ export type LLMResponse = {
   citations: Record<string, LLMCitation>;
 };
 
+export type ChatMessage = {
+  type: "user" | "assistant";
+  content: string;
+};
+
+export type QueryRequest = {
+  query: string;
+  control_number?: number;
+  history?: ChatMessage[];
+};
+
+export type PaperResponse = {
+  long_answer: string;
+};
+
 // TODO: define proper type in api.ts
 export type PaperDetails = ReturnType<typeof convertInspirePaperToAppFormat>;
 

--- a/playground/src/views/PaperView.tsx
+++ b/playground/src/views/PaperView.tsx
@@ -1,0 +1,125 @@
+import { ResponseView } from "@/views/ResponseView";
+import { ChevronDown } from "lucide-react";
+import { useRef, useState } from "react";
+import { ImperativePanelGroupHandle } from "react-resizable-panels";
+
+import { PaperCard } from "@/components/PaperCard";
+import PaperChat from "@/components/PaperChat";
+import { PaperHeader } from "@/components/paper/PaperHeader";
+import PDFManager from "@/components/pdf/PDFManager";
+import { Button } from "@/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+
+import { FormattedCitation, LLMResponse, PaperDetails } from "@/types";
+
+interface PaperViewProps {
+  activePaper: PaperDetails;
+  onClose: () => void;
+  formattedCitations: FormattedCitation[];
+  onPaperClick: (paperId: number) => void;
+  generalResponse: LLMResponse | null;
+}
+
+const PaperView = ({
+  activePaper,
+  onClose,
+  formattedCitations,
+  onPaperClick,
+  generalResponse,
+}: PaperViewProps) => {
+  const resizableGroup = useRef<ImperativePanelGroupHandle>(null);
+  const [isGeneralResponseExpanded, setIsGeneralResponseExpanded] =
+    useState(true);
+
+  return (
+    <div className="fixed inset-0 flex flex-col">
+      <PaperHeader paper={activePaper} onClose={onClose} />
+
+      <div className="mt-[5rem] h-[calc(100vh-15rem)]">
+        <ResizablePanelGroup direction="horizontal" ref={resizableGroup}>
+          <ResizablePanel defaultSize={60} minSize={25}>
+            <div className="relative h-full">
+              <div className="after:from-background h-full after:absolute after:right-0 after:bottom-0 after:left-0 after:h-12 after:bg-gradient-to-t after:to-transparent">
+                <PDFManager
+                  papers={formattedCitations.map((c) => c.paper)}
+                  activePaper={activePaper}
+                />
+              </div>
+            </div>
+          </ResizablePanel>
+          <ResizableHandle
+            withHandle
+            onDoubleClick={() => resizableGroup?.current?.setLayout([60, 40])}
+          />
+          <ResizablePanel defaultSize={40} minSize={25}>
+            <div className="flex h-full flex-col">
+              {generalResponse ? (
+                <div className="relative flex-none border-b pb-6">
+                  <ResponseView
+                    fullResponse={generalResponse}
+                    onPaperClick={onPaperClick}
+                    activePaper={activePaper}
+                    isCollapsible={true}
+                    isExpanded={isGeneralResponseExpanded}
+                  />
+
+                  <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 transform">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        setIsGeneralResponseExpanded(!isGeneralResponseExpanded)
+                      }
+                      className="bg-background h-5 w-7 shadow-sm transition-all duration-300"
+                    >
+                      <ChevronDown
+                        className={`h-3 w-3 transition-transform duration-700 ease-in-out ${
+                          isGeneralResponseExpanded ? "rotate-180" : ""
+                        }`}
+                      />
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex-none border-b p-4">
+                  <div className="text-muted-foreground text-center">
+                    <p className="text-sm">
+                      No general search result available
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              <div className="min-h-0 flex-1 pt-2">
+                <PaperChat activePaper={activePaper} />
+              </div>
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+
+      <div className="relative px-4">
+        <div className="flex gap-4 overflow-x-auto p-4">
+          {formattedCitations.map((citation) => (
+            <div key={citation.id} className="min-w-[300px]">
+              <PaperCard
+                formattedCitation={citation}
+                isActive={activePaper?.id === citation.paper.id}
+                onClick={() => onPaperClick(citation.id)}
+                displayType="footer"
+              />
+            </div>
+          ))}
+        </div>
+        <div className="from-background absolute inset-y-0 left-4 w-8 bg-gradient-to-r" />
+        <div className="from-background absolute inset-y-0 right-4 w-8 bg-gradient-to-l" />
+      </div>
+    </div>
+  );
+};
+
+export default PaperView;

--- a/playground/src/views/ResponseView.tsx
+++ b/playground/src/views/ResponseView.tsx
@@ -18,12 +18,16 @@ interface ResponseViewProps {
   fullResponse: LLMResponse;
   onPaperClick: (paperId: number) => void;
   activePaper: PaperDetails | null;
+  isCollapsible?: boolean;
+  isExpanded?: boolean;
 }
 
 export function ResponseView({
   fullResponse,
   onPaperClick,
   activePaper,
+  isCollapsible = false,
+  isExpanded = true,
 }: ResponseViewProps) {
   const { brief_answer, long_answer, citations } = fullResponse;
 
@@ -31,7 +35,7 @@ export function ResponseView({
   const renderTextWithCitations = (text: string) => {
     return text.split(/(\[\d+\])/g).map((part, index) => {
       const match = part.match(/\[(\d+)\]/);
-      if (!match) return <Latex>{part}</Latex>;
+      if (!match) return <Latex key={index}>{part}</Latex>;
 
       const citation = citations[Number(match[1]) - 1];
 
@@ -62,9 +66,7 @@ export function ResponseView({
     const [copied, setCopied] = useState(false);
 
     const copyToClipboard = () => {
-      navigator.clipboard.writeText(
-        long_answer.replace(/\s*\[(\d+:\d+)\]/g, ""),
-      );
+      navigator.clipboard.writeText(long_answer.replace(/\s*\[(\d+)\]/g, ""));
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     };
@@ -105,13 +107,17 @@ export function ResponseView({
 
   const TextContent = () => (
     <div className="prose prose-sm dark:prose-invert max-w-none">
-      <div className="mb-4 font-normal">{brief_answer}</div>
-      <p>{renderTextWithCitations(long_answer)}</p>
+      <div className="font-normal">{brief_answer}</div>
+      {(!isCollapsible || isExpanded) && (
+        <div className="mt-4">
+          <p>{renderTextWithCitations(long_answer)}</p>
+        </div>
+      )}
     </div>
   );
 
   return (
-    <div className="overflow-y-auto pb-4">
+    <div className="overflow-y-auto">
       {activePaper ? (
         <div>
           <div className="flex flex-row items-start justify-between p-6">


### PR DESCRIPTION
It is now possible to ask questions about a paper in a chat-like way. The chat keeps a conversation history, which is sent to the LLM.
- Modified query-rag endpoint to support `control_number` and history.
- Added new chain using a new prompt for papers
- The pipeline fetches the top 25 embeddings for the `control_number`. Improvements will need to be made later on as this won't be enough to put all paper content in context, especially for long papers.
- Several UI changes to accommodate this feature
- Some small general UI tweaks