### PR TITLE
integrate response feedback with langfuse

### DIFF
--- a/ai-backend/backend/src/ir_pipeline/orchestrator.py
+++ b/ai-backend/backend/src/ir_pipeline/orchestrator.py
@@ -46,6 +46,7 @@ def create_langfuse_config(user: str = None):
             "langfuse_session_id": str(uuid.uuid4()),
             **({"langfuse_user_id": user} if user else {}),
         },
+        "run_id": str(uuid.uuid4()),  # Manual trace ID for feedback
     }
 
 
@@ -272,6 +273,7 @@ async def search_rag(query: str, model: str, user: str = None):
         brief_answer=response.brief,
         long_answer=formatted_response,
         citations=citations,
+        trace_id=config.get("run_id"),
     )
 
 
@@ -305,5 +307,5 @@ async def search_rag_paper(
     formatted_response, _ = format_refs(response.response, ranked_docs)
 
     return QueryPaperResponse(
-        long_answer=formatted_response,
+        long_answer=formatted_response, trace_id=config.get("run_id")
     )

--- a/ai-backend/backend/src/schemas/feedback.py
+++ b/ai-backend/backend/src/schemas/feedback.py
@@ -6,3 +6,14 @@ from pydantic import BaseModel
 class FeedbackRequest(BaseModel):
     rating: bool
     comment: Optional[str] = None
+
+
+class RagFeedbackRequest(BaseModel):
+    trace_id: str
+    helpful: bool
+    comment: Optional[str] = None
+    score_id: Optional[str] = None
+
+
+class RagFeedbackResponse(BaseModel):
+    score_id: str

--- a/ai-backend/backend/src/schemas/query.py
+++ b/ai-backend/backend/src/schemas/query.py
@@ -28,7 +28,9 @@ class QueryResponse(BaseModel):
     brief_answer: str
     long_answer: str
     citations: List[Citation]
+    trace_id: str
 
 
 class QueryPaperResponse(BaseModel):
     long_answer: str
+    trace_id: str

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -2,18 +2,21 @@ import { Toaster } from "sonner";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 
+import { FeedbackProvider } from "./contexts/FeedbackContext";
 import { ThemeProvider } from "./providers/ThemeProvider";
 import PrimaryView from "./views/PrimaryView";
 
 const App = () => {
   return (
     <ThemeProvider>
-      <TooltipProvider>
-        <main className="flex min-h-screen flex-col pt-4 pb-50">
-          <PrimaryView />
-          <Toaster richColors />
-        </main>
-      </TooltipProvider>
+      <FeedbackProvider>
+        <TooltipProvider>
+          <main className="flex min-h-screen flex-col pt-4 pb-50">
+            <PrimaryView />
+            <Toaster richColors />
+          </main>
+        </TooltipProvider>
+      </FeedbackProvider>
     </ThemeProvider>
   );
 };

--- a/playground/src/components/PaperChat.tsx
+++ b/playground/src/components/PaperChat.tsx
@@ -14,7 +14,12 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-import { ChatMessage, PaperDetails, QueryRequest } from "@/types";
+import {
+  ChatMessage,
+  PaperDetails,
+  PaperResponse,
+  QueryRequest,
+} from "@/types";
 
 interface PaperChatProps {
   activePaper: PaperDetails;
@@ -72,7 +77,7 @@ const PaperChat = ({ activePaper }: PaperChatProps) => {
         history: chatHistory,
       };
 
-      const paperResponseData: { long_answer: string } = await fetch(
+      const paperResponseData: PaperResponse = await fetch(
         `${getInspireAiUrl()}/v1/query-rag`,
         {
           method: "POST",

--- a/playground/src/contexts/FeedbackContext.tsx
+++ b/playground/src/contexts/FeedbackContext.tsx
@@ -1,0 +1,82 @@
+import { ReactNode, createContext, useContext, useState } from "react";
+
+type FeedbackState = {
+  feedback: boolean | null;
+  scoreId?: string;
+  submittingFeedback: boolean;
+  submittedComment: string;
+};
+
+type FeedbackContextType = {
+  feedbackState: FeedbackState;
+  setFeedback: (feedback: boolean | null) => void;
+  setScoreId: (scoreId: string) => void;
+  setSubmittingFeedback: (submitting: boolean) => void;
+  setSubmittedComment: (comment: string) => void;
+  resetFeedback: () => void;
+};
+
+// Using a context in order to share feedback state across components
+// (i.e different instances of ResponseView)
+const FeedbackContext = createContext<FeedbackContextType | undefined>(
+  undefined,
+);
+
+const defaultFeedbackState: FeedbackState = {
+  feedback: null,
+  submittingFeedback: false,
+  submittedComment: "",
+};
+
+interface FeedbackProviderProps {
+  children: ReactNode;
+}
+
+export function FeedbackProvider({ children }: FeedbackProviderProps) {
+  const [feedbackState, setFeedbackState] =
+    useState<FeedbackState>(defaultFeedbackState);
+
+  const setFeedback = (feedback: boolean | null) => {
+    setFeedbackState((prev) => ({ ...prev, feedback }));
+  };
+
+  const setScoreId = (scoreId: string) => {
+    setFeedbackState((prev) => ({ ...prev, scoreId }));
+  };
+
+  const setSubmittingFeedback = (submitting: boolean) => {
+    setFeedbackState((prev) => ({ ...prev, submittingFeedback: submitting }));
+  };
+
+  const setSubmittedComment = (comment: string) => {
+    setFeedbackState((prev) => ({ ...prev, submittedComment: comment }));
+  };
+
+  const resetFeedback = () => {
+    setFeedbackState(defaultFeedbackState);
+  };
+
+  const value: FeedbackContextType = {
+    feedbackState,
+    setFeedback,
+    setScoreId,
+    setSubmittingFeedback,
+    setSubmittedComment,
+    resetFeedback,
+  };
+
+  return (
+    <FeedbackContext.Provider value={value}>
+      {children}
+    </FeedbackContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useFeedback() {
+  const context = useContext(FeedbackContext);
+  if (context === undefined) {
+    throw new Error("useFeedback must be used within a FeedbackProvider");
+  }
+  return context;
+}

--- a/playground/src/lib/ai-api.ts
+++ b/playground/src/lib/ai-api.ts
@@ -1,0 +1,37 @@
+/**
+ * Service for interacting with the AI API
+ */
+import { getInspireAiUrl } from "@/lib/utils";
+
+type FeedbackResponse = {
+  score_id: string;
+};
+
+/**
+ * Submit feedback for a RAG response
+ */
+export async function submitRagFeedback(
+  traceId: string,
+  helpful: boolean,
+  comment?: string,
+  scoreId?: string,
+): Promise<FeedbackResponse> {
+  const response = await fetch(`${getInspireAiUrl()}/v1/rag-feedback`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      trace_id: traceId,
+      helpful,
+      comment,
+      score_id: scoreId,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to submit feedback: ${response.statusText}`);
+  }
+
+  return response.json();
+}

--- a/playground/src/lib/inspire-api.ts
+++ b/playground/src/lib/inspire-api.ts
@@ -183,36 +183,3 @@ export function convertInspirePaperToAppFormat(
     document_url: metadata.documents?.find((d) => d.source == "arxiv")?.url,
   };
 }
-
-/**
- * Get random papers for initial display
- */
-// export async function getRandomPapers(count = 4): Promise<any[]> {
-//   // Get some recent papers with high citation counts
-//   const params: InspireSearchParams = {
-//     q: "topcite 100+",
-//     sort: "mostrecent",
-//     size: count,
-//     fields: [
-//       "titles",
-//       "authors.full_name",
-//       "authors.affiliations.value",
-//       "collaborations",
-//       "abstracts",
-//       "publication_info",
-//       "citation_count",
-//       "earliest_date",
-//       "arxiv_eprints",
-//       "dois",
-//       "document_type",
-//     ],
-//   };
-
-//   try {
-//     const response = await searchPapers(params);
-//     return response.hits.hits.map(convertInspirePaperToAppFormat);
-//   } catch (error) {
-//     console.error("Error fetching random papers:", error);
-//     return [];
-//   }
-// }

--- a/playground/src/types/index.ts
+++ b/playground/src/types/index.ts
@@ -1,4 +1,4 @@
-import { convertInspirePaperToAppFormat } from "@/lib/api";
+import { convertInspirePaperToAppFormat } from "@/lib/inspire-api";
 
 export type LLMCitation = {
   doc_id: number;
@@ -10,6 +10,7 @@ export type LLMResponse = {
   brief_answer: string;
   long_answer: string;
   citations: Record<string, LLMCitation>;
+  trace_id: string;
 };
 
 export type ChatMessage = {
@@ -25,6 +26,7 @@ export type QueryRequest = {
 
 export type PaperResponse = {
   long_answer: string;
+  trace_id: string;
 };
 
 // TODO: define proper type in api.ts

--- a/playground/src/views/PaperView.tsx
+++ b/playground/src/views/PaperView.tsx
@@ -60,7 +60,7 @@ const PaperView = ({
               {generalResponse ? (
                 <div className="relative flex-none border-b pb-6">
                   <ResponseView
-                    fullResponse={generalResponse}
+                    response={generalResponse}
                     onPaperClick={onPaperClick}
                     activePaper={activePaper}
                     isCollapsible={true}

--- a/playground/src/views/PrimaryView.tsx
+++ b/playground/src/views/PrimaryView.tsx
@@ -1,6 +1,10 @@
+import { useFeedback } from "@/contexts/FeedbackContext";
 import { usePDFCache } from "@/hooks/usePDFCache";
 import { usePaperChatHistory } from "@/hooks/usePaperChatHistory";
-import { convertInspirePaperToAppFormat, getPaperById } from "@/lib/api";
+import {
+  convertInspirePaperToAppFormat,
+  getPaperById,
+} from "@/lib/inspire-api";
 import { getInspireAiUrl, getPDFWithCache, getPaperUrl } from "@/lib/utils";
 import PaperView from "@/views/PaperView";
 import { ResponseView } from "@/views/ResponseView";
@@ -29,6 +33,7 @@ const PrimaryView = () => {
   const [activePaper, setActivePaper] = useState<PaperDetails | null>(null);
 
   const { clearAllHistories } = usePaperChatHistory();
+  const { resetFeedback } = useFeedback();
 
   const {
     clearCache,
@@ -49,6 +54,7 @@ const PrimaryView = () => {
 
   const handleGeneralSearch = async () => {
     clearCache();
+    resetFeedback();
     setActivePaper(null);
     clearAllHistories();
     setIsLoading(true);
@@ -233,7 +239,7 @@ const PrimaryView = () => {
             response && (
               <div>
                 <ResponseView
-                  fullResponse={response}
+                  response={response}
                   onPaperClick={handlePaperClick}
                   activePaper={activePaper}
                 />


### PR DESCRIPTION
Closes https://github.com/cern-sis/issues-inspire/issues/993

Integrates the UI feedback elements with the langfuse user feedback tracing.
- Added also a comment button next to the existing thumbs up and thumbs down
- Feedback is linked to the langfuse trace of the response
- When clicking back and forth between thumbs up/down or adding a comment, the feedback is linked with the langfuse score_id for that trace, in order to prevent duplicate entries, and will instead do an upsert.
- When adding a comment with no rating selected, the thumbs up will be selected by default (it can be modified by the user afterwards)